### PR TITLE
Msg'ing and strict updates

### DIFF
--- a/R/tidy_add_header_rows.R
+++ b/R/tidy_add_header_rows.R
@@ -23,6 +23,7 @@
 #' @param show_single_row a vector indicating the names of binary
 #' variables that should be displayed on a single row
 #' @param model the corresponding model, if not attached to `x`
+#' @inheritParams tidy_plus_plus
 #' @export
 #' @family tidy_helpers
 #' @examples
@@ -56,7 +57,10 @@
 #'     tidy_add_reference_rows() %>%
 #'     tidy_add_header_rows()
 #' }
-tidy_add_header_rows <- function(x, show_single_row = NULL, model = tidy_get_model(x)) {
+tidy_add_header_rows <- function(x,
+                                 show_single_row = NULL,
+                                 model = tidy_get_model(x),
+                                 strict = FALSE) {
   if (is.null(model)) {
     stop("'model' is not provided. You need to pass it or to use 'tidy_and_attach()'.")
   }
@@ -73,6 +77,23 @@ tidy_add_header_rows <- function(x, show_single_row = NULL, model = tidy_get_mod
   # management of show_single_row --------------
   # only if reference_rows have been defined
   show_single_row <- stats::na.omit(unique(show_single_row))
+
+  # checking if variables incorrectly requested for single row summary
+  bad_single_row <- x %>%
+    dplyr::filter(!is.na(.data$estimate),
+                  !is.na(.data$variable),
+                  .data$variable %in% show_single_row) %>%
+    dplyr::group_by(.data$variable) %>%
+    dplyr::count() %>%
+    dplyr::filter(.data$n > 1) %>%
+    dplyr::pull(.data$variable)
+  if (length(bad_single_row) > 0) {
+    paste("Variable(s) {paste(shQuote(bad_single_row), collapse = ", ")} were",
+          "incorrectly requested to be printed on a single row.") %>%
+    usethis::ui_oops()
+    if (strict) stop("Quitting execution.", call. = FALSE)
+  }
+
   if (
     length(show_single_row) > 0 &&
       "reference_row" %in% names(x) &&

--- a/R/tidy_identify_variables.R
+++ b/R/tidy_identify_variables.R
@@ -10,6 +10,7 @@
 #' of variables.
 #' @param x a tidy tibble
 #' @param model the corresponding model, if not attached to `x`
+#' @inheritParams tidy_plus_plus
 #' @export
 #' @seealso [model_identify_variables()]
 #' @family tidy_helpers
@@ -28,7 +29,7 @@
 #' ) %>%
 #'   tidy_and_attach(conf.int = TRUE) %>%
 #'   tidy_identify_variables()
-tidy_identify_variables <- function(x, model = tidy_get_model(x)) {
+tidy_identify_variables <- function(x, model = tidy_get_model(x), strict = FALSE) {
   if (is.null(model)) {
     stop("'model' is not provided. You need to pass it or to use 'tidy_and_attach()'.")
   }
@@ -74,6 +75,7 @@ tidy_identify_variables <- function(x, model = tidy_get_model(x)) {
       "functional programming framework (e.g. using {usethis::ui_code('lappy()')}, ",
       "{usethis::ui_code('purrr::map()')}, etc.)."
     ))
+    if (strict) stop("Quitting execution.", call. = FALSE)
     x %>%
       dplyr::mutate(
         variable = NA_character_,

--- a/R/tidy_plus_plus.R
+++ b/R/tidy_plus_plus.R
@@ -28,6 +28,8 @@
 #' `add_header_rows` is `TRUE`
 #' @param intercept should the intercept(s) be included?
 #' @param keep_model should the model be kept as an attribute of the final result?
+#' @param strict logical argument whether broom.helpers should return an error
+#' when requested output cannot be generated. Default is FALSE
 #' @param ... other arguments passed to `tidy_fun()`
 #' @family tidy_helpers
 #' @examples
@@ -87,6 +89,7 @@ tidy_plus_plus <- function(
                            show_single_row = NULL,
                            intercept = FALSE,
                            keep_model = FALSE,
+                           strict = FALSE,
                            ...) {
   res <- model %>%
     tidy_and_attach(
@@ -95,7 +98,7 @@ tidy_plus_plus <- function(
       exponentiate = exponentiate,
       ...
     ) %>%
-    tidy_identify_variables() %>%
+    tidy_identify_variables(strict = strict) %>%
     tidy_add_contrasts()
   if (add_reference_rows) {
     res <- res %>% tidy_add_reference_rows()
@@ -109,7 +112,7 @@ tidy_plus_plus <- function(
     tidy_add_term_labels(labels = term_labels)
   if (add_header_rows) {
     res <- res %>%
-      tidy_add_header_rows(show_single_row = show_single_row)
+      tidy_add_header_rows(show_single_row = show_single_row, strict = strict)
   }
   if (!intercept) {
     res <- res %>% tidy_remove_intercept()

--- a/man/tidy_add_header_rows.Rd
+++ b/man/tidy_add_header_rows.Rd
@@ -4,7 +4,12 @@
 \alias{tidy_add_header_rows}
 \title{Add header rows variables with several terms}
 \usage{
-tidy_add_header_rows(x, show_single_row = NULL, model = tidy_get_model(x))
+tidy_add_header_rows(
+  x,
+  show_single_row = NULL,
+  model = tidy_get_model(x),
+  strict = FALSE
+)
 }
 \arguments{
 \item{x}{a tidy tibble}
@@ -13,6 +18,9 @@ tidy_add_header_rows(x, show_single_row = NULL, model = tidy_get_model(x))
 variables that should be displayed on a single row}
 
 \item{model}{the corresponding model, if not attached to \code{x}}
+
+\item{strict}{logical argument whether broom.helpers should return an error
+when requested output cannot be generated. Default is FALSE}
 }
 \description{
 For variables with several terms (usually categorical variables but

--- a/man/tidy_identify_variables.Rd
+++ b/man/tidy_identify_variables.Rd
@@ -4,12 +4,15 @@
 \alias{tidy_identify_variables}
 \title{Identify the variable corresponding to each model coefficient}
 \usage{
-tidy_identify_variables(x, model = tidy_get_model(x))
+tidy_identify_variables(x, model = tidy_get_model(x), strict = FALSE)
 }
 \arguments{
 \item{x}{a tidy tibble}
 
 \item{model}{the corresponding model, if not attached to \code{x}}
+
+\item{strict}{logical argument whether broom.helpers should return an error
+when requested output cannot be generated. Default is FALSE}
 }
 \description{
 \code{tidy_identify_variables()} will add to the tidy tibble

--- a/man/tidy_plus_plus.Rd
+++ b/man/tidy_plus_plus.Rd
@@ -17,6 +17,7 @@ tidy_plus_plus(
   show_single_row = NULL,
   intercept = FALSE,
   keep_model = FALSE,
+  strict = FALSE,
   ...
 )
 }
@@ -48,6 +49,9 @@ variables that should be displayed on a single row, when
 \item{intercept}{should the intercept(s) be included?}
 
 \item{keep_model}{should the model be kept as an attribute of the final result?}
+
+\item{strict}{logical argument whether broom.helpers should return an error
+when requested output cannot be generated. Default is FALSE}
 
 \item{...}{other arguments passed to \code{tidy_fun()}}
 }

--- a/tests/testthat/test-add_header_rows.R
+++ b/tests/testthat/test-add_header_rows.R
@@ -161,3 +161,17 @@ test_that("tidy_add_header_rows() works with nnet::multinom", {
     )
   )
 })
+
+
+test_that("test tidy_add_header_rows() bad single row request", {
+  mod <- lm(mpg ~ hp + factor(cyl) + factor(am), mtcars) %>%
+    tidy_and_attach() %>%
+    tidy_identify_variables()
+
+  expect_message(
+    tidy_add_header_rows(mod, show_single_row = "factor(cyl)")
+  )
+  expect_error(
+    tidy_add_header_rows(mod, show_single_row = "factor(cyl)", strict = TRUE)
+  )
+})


### PR DESCRIPTION
- added a message to users when they request variables to be reported on a single line, when they cannot be (#33)
- added a strict argument to `tidy_add_header_rows()` and `tidy_identify_variables()` to return an error when request cannot be executed.

closes #33 
closes #34 