### PR TITLE
Change arg name in `tidy_select_variables()`

### DIFF
--- a/R/tidy_plus_plus.R
+++ b/R/tidy_plus_plus.R
@@ -31,7 +31,7 @@
 #' on a single row (accepts tidyselect notation), when
 #' `add_header_rows` is `TRUE`
 #' @param intercept should the intercept(s) be included?
-#' @param keep variables to keep (accepts tidyselect notation).
+#' @param include variables to include (accepts tidyselect notation).
 #' Use `-` to remove a variable. Default is `everything()`
 #' @param keep_model should the model be kept as an attribute of the final result?
 #' @param quiet logical argument whether broom.helpers should not return a message
@@ -97,7 +97,7 @@ tidy_plus_plus <- function(
                            add_header_rows = FALSE,
                            show_single_row = NULL,
                            intercept = FALSE,
-                           keep = everything(),
+                           include = everything(),
                            keep_model = FALSE,
                            quiet = FALSE,
                            strict = FALSE,
@@ -133,7 +133,7 @@ tidy_plus_plus <- function(
     res <- res %>% tidy_remove_intercept()
   }
   res <- res %>% tidy_select_variables(
-    keep = {{ keep }},
+    include = {{ include }},
   ) %>%
     tidy_add_coefficients_type()
   if (!keep_model) {

--- a/R/tidy_select_variables.R
+++ b/R/tidy_select_variables.R
@@ -7,8 +7,8 @@
 #' If the `variable` column is not yet available in `x`,
 #' [tidy_identify_variables()] will be automatically applied.
 #' @param x a tidy tibble
-#' @param keep variables to keep. Use `-` to remove a variable.
-#' Default is `everything()`
+#' @param include variables to include. Accepts tidyselect syntax.
+#' Use `-` to remove a variable. Default is `everything()`
 #' @param model the corresponding model, if not attached to `x`
 #' @export
 #' @family tidy_helpers
@@ -22,12 +22,12 @@
 #'
 #' res
 #' res %>% tidy_select_variables()
-#' res %>% tidy_select_variables(keep = "Class")
-#' res %>% tidy_select_variables(keep = -c("Age", "Sex"))
-#' res %>% tidy_select_variables(keep = starts_with("A"))
+#' res %>% tidy_select_variables(include = "Class")
+#' res %>% tidy_select_variables(include = -c("Age", "Sex"))
+#' res %>% tidy_select_variables(include = starts_with("A"))
 
 tidy_select_variables <- function(
-  x, keep = everything(), model = tidy_get_model(x)
+  x, include = everything(), model = tidy_get_model(x)
 ) {
   if (is.null(model)) {
     stop("'model' is not provided. You need to pass it or to use 'tidy_and_attach()'.")
@@ -39,12 +39,12 @@ tidy_select_variables <- function(
   .attributes <- .save_attributes(x)
 
   # obtain character vector of selected variables
-  keep <- .tidy_tidyselect(x, {{ keep }})
+  include <- .tidy_tidyselect(x, {{ include }})
 
   x %>%
     dplyr::filter(
       .data$var_type == "intercept" |
-        .data$variable %in% keep
+        .data$variable %in% include
     ) %>%
     tidy_attach_model(model = model, .attributes = .attributes)
 

--- a/man/tidy_plus_plus.Rd
+++ b/man/tidy_plus_plus.Rd
@@ -17,7 +17,7 @@ tidy_plus_plus(
   add_header_rows = FALSE,
   show_single_row = NULL,
   intercept = FALSE,
-  keep = everything(),
+  include = everything(),
   keep_model = FALSE,
   quiet = FALSE,
   strict = FALSE,
@@ -54,7 +54,7 @@ on a single row (accepts tidyselect notation), when
 
 \item{intercept}{should the intercept(s) be included?}
 
-\item{keep}{variables to keep (accepts tidyselect notation).
+\item{include}{variables to include (accepts tidyselect notation).
 Use \code{-} to remove a variable. Default is \code{everything()}}
 
 \item{keep_model}{should the model be kept as an attribute of the final result?}

--- a/man/tidy_select_variables.Rd
+++ b/man/tidy_select_variables.Rd
@@ -4,13 +4,13 @@
 \alias{tidy_select_variables}
 \title{Select variables to keep/drop}
 \usage{
-tidy_select_variables(x, keep = everything(), model = tidy_get_model(x))
+tidy_select_variables(x, include = everything(), model = tidy_get_model(x))
 }
 \arguments{
 \item{x}{a tidy tibble}
 
-\item{keep}{variables to keep. Use \code{-} to remove a variable.
-Default is \code{everything()}}
+\item{include}{variables to include. Accepts tidyselect syntax.
+Use \code{-} to remove a variable. Default is \code{everything()}}
 
 \item{model}{the corresponding model, if not attached to \code{x}}
 }
@@ -32,9 +32,9 @@ res <- Titanic \%>\%
 
 res
 res \%>\% tidy_select_variables()
-res \%>\% tidy_select_variables(keep = "Class")
-res \%>\% tidy_select_variables(keep = -c("Age", "Sex"))
-res \%>\% tidy_select_variables(keep = starts_with("A"))
+res \%>\% tidy_select_variables(include = "Class")
+res \%>\% tidy_select_variables(include = -c("Age", "Sex"))
+res \%>\% tidy_select_variables(include = starts_with("A"))
 }
 \seealso{
 Other tidy_helpers: 

--- a/tests/testthat/test-select_variables.R
+++ b/tests/testthat/test-select_variables.R
@@ -8,13 +8,13 @@ test_that("tidy_select_variables() works for basic models", {
   res2 <- res %>% tidy_select_variables()
   expect_equivalent(res, res2)
 
-  # keep
-  res2 <- res %>% tidy_select_variables(keep = "stage")
+  # include
+  res2 <- res %>% tidy_select_variables(include = "stage")
   expect_equivalent(
     res2$variable,
     c(NA, "stage", "stage", "stage")
   )
-  res2 <- res %>% tidy_select_variables(keep = c("grade", "trt"))
+  res2 <- res %>% tidy_select_variables(include = c("grade", "trt"))
   expect_equivalent(
     res2$variable,
     c(NA, "grade", "grade", "trt")
@@ -22,33 +22,33 @@ test_that("tidy_select_variables() works for basic models", {
 
   # select and de-select
   expect_equivalent(
-    res %>% tidy_select_variables(keep = stage),
-    res %>% tidy_select_variables(keep = -c(grade, trt))
+    res %>% tidy_select_variables(include = stage),
+    res %>% tidy_select_variables(include = -c(grade, trt))
   )
 
   # tidyselect fns
   expect_equivalent(
-    res %>% tidy_select_variables(keep = contains("tage")),
-    res %>% tidy_select_variables(keep = stage)
+    res %>% tidy_select_variables(include = contains("tage")),
+    res %>% tidy_select_variables(include = stage)
   )
 
   # testing vars() selector
   expect_equivalent(
-    res %>% tidy_select_variables(keep = vars(grade, trt)),
-    res %>% tidy_select_variables(keep = c(grade, trt))
+    res %>% tidy_select_variables(include = vars(grade, trt)),
+    res %>% tidy_select_variables(include = c(grade, trt))
   )
 
   # no error when none selected
   expect_error(
-    res %>% tidy_select_variables(keep = starts_with("zzzzzzz")),
+    res %>% tidy_select_variables(include = starts_with("zzzzzzz")),
     NA
   )
   expect_error(
-    res %>% tidy_select_variables(keep = -everything()),
+    res %>% tidy_select_variables(include = -everything()),
     NA
   )
   expect_error(
-    res %>% tidy_select_variables(keep = where(is.character)),
+    res %>% tidy_select_variables(include = where(is.character)),
     NA
   )
 })

--- a/tests/testthat/test-tidy_plus_plus.R
+++ b/tests/testthat/test-tidy_plus_plus.R
@@ -1,7 +1,7 @@
 test_that("tidy_plus_plus() works for basic models", {
   mod <- glm(response ~ stage + grade + trt, gtsummary::trial, family = binomial)
   expect_error(
-    mod %>% tidy_plus_plus(add_header_rows = TRUE, keep = c(stage, grade)),
+    mod %>% tidy_plus_plus(add_header_rows = TRUE, include = c(stage, grade)),
     NA
   )
 })


### PR DESCRIPTION
Updating the argument name `tidy_select_variables(keep=)` to `tidy_select_variables(include=)` to be consistent with the existing gtsummary argument names.

closes #52