### PR TITLE
Select scoping update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.0.0.9002
+Version: 1.0.0.9003
 Authors@R: 
     c(person(given = "Joseph",
              family = "Larmarange",

--- a/R/model_identify_variables.R
+++ b/R/model_identify_variables.R
@@ -133,7 +133,7 @@ model_identify_variables.clm <- function(model) {
   if (is.null(model$alpha.mat)) {
     res <- dplyr::bind_rows(
       res %>%
-        dplyr::filter(term != "(Intercept)"),
+        dplyr::filter(.data$term != "(Intercept)"),
       dplyr::tibble(
         term = names(model$alpha),
         var_type = "intercept"

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -177,14 +177,8 @@
   rm(list = ls(envir = env_variable_type), envir = env_variable_type)
   if (!inherits(x, "data.frame")) return(invisible(NULL))
 
-  # saving list of variable types to selecting environment
-  df_var_info <-
-    x %>%
-    dplyr::select(any_of(c("variable", "var_label", "var_class",
-                           "var_type", "var_nlevels", "contrasts", "contrasts_type"))) %>%
-    dplyr::distinct()
-
-  env_variable_type$df_var_info <- df_var_info
+  # saving var_info to selecting environment, where it may be utilized by selecting fns
+  env_variable_type$df_var_info <- x
 
   return(invisible(NULL))
 }


### PR DESCRIPTION
When the broom.helpers tidy data frame was scoped (for use with the `all_*()` selecting functions), it previously specified the columns that could be used in all selecting and all future selecting functions.

I was implementing a new feature in gtsummary, and needed to scope a column not previously listed.  This update removes the step of selecting which columns can be used and allows for any column to be used in a new selecting function.