### PR TITLE
 formula-list values with more flexible inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Authors@R: 
     c(person(given = "Joseph",
              family = "Larmarange",
@@ -70,5 +70,5 @@ RdMacros:
     lifecycle
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 - Support for `glmmTMB::glmmTMB()` models (#119)
 
+**New features**
+
+- Function arguments that accept formula-list values now have more flexible inputs. (#121)
+  - The passed list may now be a combination of named lists and lists of formulas, e.g. `list(trt ~ 1, all_continuous() ~ 2)`.
+  - The shortcut `~ <value>` may be now used to indicate `everything() ~ <value>`
+
 **Bug fixes**
 
 - Bug fix for computing n for some binomial models computed 

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -283,12 +283,13 @@ test_that("select_helpers: .formula_list_to_named_list ", {
     list(age = "Age")
   )
 
-  expect_error(
-    .formula_list_to_named_list(~ "Age", var_info = tidy_mod)
+  expect_equal(
+    .formula_list_to_named_list(~ "Age", var_info = tidy_mod),
+    list(age = "Age", trt = "Age", grade = "Age", `age:trt` = "Age")
   )
-
-  expect_error(
-    .formula_list_to_named_list(~ "Age", var_info = tidy_mod, arg_name = "labels")
+  expect_equal(
+    .formula_list_to_named_list(list(~ "Age", `age:trt` = "interact"), var_info = tidy_mod),
+    list(age = "Age", trt = "Age", grade = "Age", `age:trt` = "interact")
   )
 })
 


### PR DESCRIPTION
- Function arguments that accept formula-list values now have more flexible inputs. (#121)
  - The passed list may now be a combination of named lists and lists of formulas, e.g. `list(trt ~ 1, all_continuous() ~ 2)`.
  - The shortcut `~ <value>` may be now used to indicate `everything() ~ <value>`

closes #121 