### PR TITLE
Error message update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Bug fix for identifying the levels of a logical variable (#125)
 
+- Updated error messaging about using `broom.helpers::tidy_paramters()` to include the package prefix. This message sometimes appears while running `gtsummary::tbl_regression()` where some users may not be aware where the `tidy_paramters()` function lives.
+
 # broom.helpers 1.4.0
 
 **New supported models**

--- a/R/tidiers.R
+++ b/R/tidiers.R
@@ -89,7 +89,7 @@ tidy_with_broom_or_parameters <- function(x, conf.int = TRUE, conf.level = .95, 
     } else {
       # success of parameters
       cli::cli_alert_success("{.code tidy_parameters()} used instead.")
-      cli::cli_alert_info("Add {.code tidy_fun = tidy_parameters} to quiet these messages.")
+      cli::cli_alert_info("Add {.code tidy_fun = broom.helpers::tidy_parameters} to quiet these messages.")
     }
   }
   res


### PR DESCRIPTION
- Updated error messaging about using `broom.helpers::tidy_paramters()` after `broom::tidy()` fails. The message now includes the package prefix. This message sometimes appears while running `gtsummary::tbl_regression()` where some users may not be aware where the `tidy_paramters()` function lives.