### PR TITLE
`.formula_list_to_named_list()` improvements IN PROGRESS

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,5 @@
+# this sets the dev folder in the libPath
+tryCatch(
+  devtools::dev_mode(on = TRUE),
+  error = function(e) invisible()
+)

--- a/.github/workflows/R-CMD-historic-R-check.yaml
+++ b/.github/workflows/R-CMD-historic-R-check.yaml
@@ -77,8 +77,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
+          remotes::install_deps(dependencies = TRUE, repos = "http://cran.rstudio.com/")
+          remotes::install_cran("rcmdcheck", repos = "http://cran.rstudio.com/")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-historic-R-check.yaml
+++ b/.github/workflows/R-CMD-historic-R-check.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages('remotes', repos = "http://cran.rstudio.com/")
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}

--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -25,11 +25,11 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v1
       - name: Install rmarkdown, remotes, and the local package
         run: |
-          install.packages("remotes", type = "binary")
-          remotes::install_local(".", type = "binary")
-          remotes::install_cran("rmarkdown", type = "binary")
-          remotes::install_cran("gtsummary", type = "binary")
-          remotes::install_cran("emmeans", type = "binary")
+          install.packages("remotes", type = "binary", repos = "http://cran.rstudio.com/")
+          remotes::install_local(".", type = "binary", repos = "http://cran.rstudio.com/")
+          remotes::install_cran("rmarkdown", type = "binary", repos = "http://cran.rstudio.com/")
+          remotes::install_cran("gtsummary", type = "binary", repos = "http://cran.rstudio.com/")
+          remotes::install_cran("emmeans", type = "binary", repos = "http://cran.rstudio.com/")
         shell: Rscript {0}
       - name: Render README
         run: Rscript -e 'rmarkdown::render("README.Rmd")'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Query dependencies
         run: |
-          install.packages('remotes')
+          install.packages('remotes', repos = "http://cran.rstudio.com/")
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
@@ -38,9 +38,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE, type = "binary")
-          remotes::install_cran("covr", type = "binary")
+          install.packages(c("remotes"), repos = "http://cran.rstudio.com/")
+          remotes::install_deps(dependencies = TRUE, type = "binary", repos = "http://cran.rstudio.com/")
+          remotes::install_cran("covr", type = "binary", repos = "http://cran.rstudio.com/")
         shell: Rscript {0}
 
       - name: Test coverage

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.4.0.9000
+Version: 1.4.0.9001
 Authors@R: 
     c(person(given = "Joseph",
              family = "Larmarange",

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   to include the package prefix. This message sometimes appears while
   running `gtsummary::tbl_regression()` where some users may not be
   aware where the `tidy_paramters()` function lives.
+- `.formula_list_to_named_list()` improvement: it is now possible to add
+  a type check (#132)
 
 # broom.helpers 1.4.0
 

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -79,10 +79,10 @@
         "'https://www.danieldsjoberg.com/gtsummary/reference/syntax.html'")
     if (tryCatch(do.call(type_check, list(x)), error = function(e) FALSE)) {
       x_string <-
-        tryCatch(
+        suppressWarnings(tryCatch(
           switch(rlang::is_string(x)) %||% as.character(deparse(x)),
           error = function(e) NULL
-        )
+        ))
       if (!is.null(x_string) && nchar(x_string) <= 50) {
         err_msg <-
           paste(
@@ -119,7 +119,7 @@
   if (!is.null(type_check) && !type_check(rhs)) {
     type_check_msg %||%
       stringr::str_glue(
-        "Error processing `{arg_name %||% ''}` argument for element '{lhs[[1]]}'.",
+        "Error processing `{arg_name %||% ''}` argument for element '{lhs[[1]]}'. ",
         "The value passed is not the expected type/class.") %>%
       stop(call. = FALSE)
   }

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -36,8 +36,8 @@
   # checking the input is a list -----------------------------------------------
   if (!rlang::is_list(x)) {
     stringr::str_glue(
-      "Error processing the `{argname}` argument. ",
-      "Expecting `x=` to be a list or formula. ",
+      "Error processing the `{argname %||% ''}` argument. ",
+      "Expecting a list or formula. ",
       "Review syntax details at",
       "'https://www.danieldsjoberg.com/gtsummary/reference/syntax.html' ") %>%
       stop(call. = FALSE)
@@ -90,7 +90,7 @@
   # check the type of RHS ------------------------------------------------------
   if (!is.null(type_check) && !type_check(rhs)) {
     stringr::str_glue(
-      "Error processing `{arg_name}` argument for element '{lhs[[1]]}'.",
+      "Error processing `{arg_name %||% ''}` argument for element '{lhs[[1]]}'.",
       "The value passed is not the expected type/class.") %>%
       stop(call. = FALSE)
   }

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -34,7 +34,8 @@
   }
 
   # checking the input is a list -----------------------------------------------
-  if (!rlang::is_list(x)) {
+  if (!rlang::is_list(x) &&
+      !(rlang::is_bare_vector(x) && rlang::is_named(x))) {
     stringr::str_glue(
       "Error processing the `{argname %||% ''}` argument. ",
       "Expecting a list or formula. ",

--- a/man/dot-formula_list_to_named_list.Rd
+++ b/man/dot-formula_list_to_named_list.Rd
@@ -9,7 +9,8 @@
   data = NULL,
   var_info = NULL,
   arg_name = NULL,
-  select_single = FALSE
+  select_single = FALSE,
+  type_check = NULL
 )
 }
 \arguments{
@@ -25,6 +26,10 @@ helps in the error messaging. Default is NULL.}
 
 \item{select_single}{Logical indicating whether the result must be a single
 variable. Default is \code{FALSE}}
+
+\item{type_check}{A predicate function that checks the elements passed on
+the RHS of the formulas in \verb{x=} (or the element in a named list)
+satisfy the function.}
 }
 \description{
 Functions takes a list of formulas, a named list, or a combination of named

--- a/man/dot-formula_list_to_named_list.Rd
+++ b/man/dot-formula_list_to_named_list.Rd
@@ -10,7 +10,8 @@
   var_info = NULL,
   arg_name = NULL,
   select_single = FALSE,
-  type_check = NULL
+  type_check = NULL,
+  type_check_msg = NULL
 )
 }
 \arguments{
@@ -30,6 +31,10 @@ variable. Default is \code{FALSE}}
 \item{type_check}{A predicate function that checks the elements passed on
 the RHS of the formulas in \verb{x=} (or the element in a named list)
 satisfy the function.}
+
+\item{type_check_msg}{When the \verb{type_check=} fails, the string provided
+here will be printed as the error message. When \code{NULL}, a generic
+error message will be printed.}
 }
 \description{
 Functions takes a list of formulas, a named list, or a combination of named

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -278,6 +278,20 @@ test_that("select_helpers: .formula_list_to_named_list ", {
     .formula_list_to_named_list(list(age ~ "Age", TRUE), var_info = tidy_mod)
   )
 
+  expect_error(
+    .formula_list_to_named_list(list(age ~ "Age"), var_info = tidy_mod,
+                                type_check = is.character),
+    NA
+  )
+  expect_error(
+    .formula_list_to_named_list(list(age ~ "Age"), var_info = tidy_mod,
+                                type_check = is.logical)
+  )
+  expect_error(
+    .formula_list_to_named_list(letters, var_info = tidy_mod,
+                                type_check = is.logical)
+  )
+
   expect_equal(
     .formula_list_to_named_list(age ~ "Age", var_info = tidy_mod),
     list(age = "Age")

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -305,6 +305,23 @@ test_that("select_helpers: .formula_list_to_named_list ", {
     .formula_list_to_named_list(list(~ "Age", `age:trt` = "interact"), var_info = tidy_mod),
     list(age = "Age", trt = "Age", grade = "Age", `age:trt` = "interact")
   )
+
+  expect_error(
+    .formula_list_to_named_list(list(age ~ "Age"), var_info = tidy_mod, type_check = is.logical,
+                                arg_name = "label")
+  )
+  expect_error(
+    .formula_list_to_named_list(list(age ~ "Age"), var_info = tidy_mod,
+                                type_check = is.logical, arg_name = "label",
+                                type_check_msg = "Age msg error")
+  )
+  expect_error(
+    .formula_list_to_named_list("Age", var_info = tidy_mod,
+                                type_check = rlang::is_string,
+                                arg_name = "label",
+                                type_check_msg = "Age msg error")
+  )
+
 })
 
 

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -319,9 +319,13 @@ test_that("select_helpers: .formula_list_to_named_list ", {
   expect_error(
     .formula_list_to_named_list("Age", var_info = tidy_mod,
                                 type_check = rlang::is_string,
-                                arg_name = "label",
-                                type_check_msg = "Age msg error"),
-    "*"
+                                arg_name = "label")
+  )
+  expect_error(
+    .formula_list_to_named_list(~ "Age", var_info = tidy_mod,
+                                type_check = rlang::is_string,
+                                arg_name = "label"),
+    NA
   )
 
 })

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -313,13 +313,15 @@ test_that("select_helpers: .formula_list_to_named_list ", {
   expect_error(
     .formula_list_to_named_list(list(age ~ "Age"), var_info = tidy_mod,
                                 type_check = is.logical, arg_name = "label",
-                                type_check_msg = "Age msg error")
+                                type_check_msg = "Age msg error"),
+    "Age msg error"
   )
   expect_error(
     .formula_list_to_named_list("Age", var_info = tidy_mod,
                                 type_check = rlang::is_string,
                                 arg_name = "label",
-                                type_check_msg = "Age msg error")
+                                type_check_msg = "Age msg error"),
+    "*"
   )
 
 })


### PR DESCRIPTION
- Added checks to `.formula_list_to_named_list(x=)` type to ensure a list or formula has been passed. Check triggers improved messaging instructing users of the correct syntax.
- Added a `.formula_list_to_named_list(type_check=)` argument. Argument accepts a predicate function as the input and checks the RHS of the formula passes the predicate check.