### PR TITLE
Fix in `.formula_list_to_named_list(select_single=)` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.5.0.9001
+Version: 1.5.0.9002
 Authors@R: 
     c(person(given = "Joseph",
              family = "Larmarange",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # broom.helpers (development version)
 
+- The `.formula_list_to_named_list()` now respects the `select_single=` 
+  argument for all inputs types. Previously, named lists were ignored.
 - Added new argument `.formula_list_to_named_list(null_allowed=)` argument 
   that works in conjunction with `type_check=` asserting the class/type of 
   the RHS of the formula (or the value of the named list) (#137)

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -72,7 +72,27 @@
 
   # removing duplicates (using the last one listed if variable occurs more than once)
   tokeep <- names(named_list) %>% rev() %>% {!duplicated(.)} %>% rev()
-  named_list[tokeep]
+  result <- named_list[tokeep]
+
+  if (isTRUE(select_single) && length(result) > 1) {
+    .select_single_error_msg(names(result), arg_name = arg_name)
+  }
+  result
+}
+
+.select_single_error_msg <- function(selected, arg_name) {
+  if (!rlang::is_empty(arg_name)) {
+    stringr::str_glue(
+      "Error in `{arg_name}=` argument--select only a single column. ",
+      "The following columns were selected, ",
+      "{paste(sQuote(selected), collapse = ', ')}") %>%
+      stop(call. = FALSE)
+  }
+  stringr::str_glue(
+    "Error in selector--select only a single column. ",
+    "The following columns were selected, ",
+    "{paste(sQuote(selected), collapse = ', ')}") %>%
+    stop(call. = FALSE)
 }
 
 .check_valid_input <- function(x, arg_name, type_check) {
@@ -228,11 +248,7 @@
 
   # assuring only a single column is selected
   if (select_single == TRUE && length(res) > 1) {
-    stop(stringr::str_glue(
-      "Error in `{arg_name}=` argument input--select only a single column. ",
-      "The following columns were selected, ",
-      "{paste(sQuote(res), collapse = ', ')}"
-    ), call. = FALSE)
+    .select_single_error_msg(res, arg_name = arg_name)
   }
 
   # if nothing is selected, return a NULL

--- a/tests/testthat/test-select_helpers.R
+++ b/tests/testthat/test-select_helpers.R
@@ -371,6 +371,22 @@ test_that("select_helpers: .formula_list_to_named_list ", {
       null_allowed = FALSE
     )
   )
+
+  expect_error(
+    .formula_list_to_named_list(
+      list(response = "Response", dplyr::contains("age") ~ "?AGE?", trt = NULL),
+      data = gtsummary::trial,
+      arg_name = "label",
+      select_single = TRUE
+    )
+  )
+  expect_error(
+    .formula_list_to_named_list(
+      list(response = "Response", dplyr::contains("age") ~ "?AGE?", trt = NULL),
+      data = gtsummary::trial,
+      select_single = TRUE
+    )
+  )
 })
 
 


### PR DESCRIPTION
Enforcing the select single argument to ensure that only a single element is select when `select_single = TRUE`.