### PR TITLE
Using rlang to check pkg install status

### DIFF
--- a/.github/workflows/R-CMD-historic-R-check.yaml
+++ b/.github/workflows/R-CMD-historic-R-check.yaml
@@ -69,12 +69,6 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
-      - name: Install historical dependencies 3.4
-        run: Rscript -e "if (substr(getRversion(), 1, 3) == '3.4') install.packages(c('emmeans', 'gam', 'geepack', 'mice', 'brms'), repos = 'https://mran.microsoft.com/snapshot/2018-04-01/')"
-
-      - name: Install historical dependencies 3.5
-        run: Rscript -e "if (substr(getRversion(), 1, 3) == '3.5') install.packages(c('brms'), repos = 'https://mran.microsoft.com/snapshot/2019-03-15/')"
-
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE, repos = "http://cran.rstudio.com/")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.6.0.9000
+Version: 1.6.0.9001
 Authors@R: c(
     person("Joseph", "Larmarange", , "joseph@larmarange.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7097-700X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     labelled,
     lifecycle,
     purrr,
-    rlang,
+    rlang (>= 1.0.1),
     stats,
     stringr,
     tibble,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     knitr,
     lavaan,
     lfe,
-    lme4,
+    lme4 (>= 1.1.28),
     MASS,
     mgcv,
     mice,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 **New features**
 
+- The `.assert_package()` now uses `rlang::check_installed()` and `rlang::is_installed()` to check whether needed packages are installed. The `rlang::check_installed()` prompts user to install needed package when run interactively. (#147)
 - `tidy_add_n()` and `model_get_n()` support for `tidycmprsk::crr()` 
   models (#143)
 - Listing of supported models is now available in `supported_models` tibble (#145)

--- a/R/assert_package.R
+++ b/R/assert_package.R
@@ -26,31 +26,18 @@ NULL
 .assert_package <- function(pkg, fn = NULL, pkg_search = "broom.helpers", boolean = FALSE) {
   # check if min version is required -------------------------------------------
   version <- .get_min_version_required(pkg, pkg_search)
-  if (is.null(version) && !requireNamespace(pkg, quietly = TRUE)) {
-    if (!is.null(fn)) {
-      cli_alert_danger("The {.val {pkg}} package is required for function {.code {fn}}.")
-    }
-    cli_ul("Install {.val {pkg}} with the code below.")
-    cli_code(glue::glue('install.packages("{pkg}")'))
-    if (isTRUE(boolean)) return(FALSE)
-    stop("Install required package", call. = FALSE)
+
+  # check installation TRUE/FALSE ----------------------------------------------
+  if (isTRUE(boolean)) {
+    return(rlang::is_installed(pkg = pkg, version = version))
   }
 
-  if (!is.null(version) &&
-      (!requireNamespace(pkg, quietly = TRUE) ||
-       (requireNamespace(pkg, quietly = TRUE) && utils::packageVersion(pkg) < version))) {
-    if (!is.null(fn)) {
-      paste("The {.val {pkg}} package {.field v{version}} or greater is",
-            "required for function {.code {fn}}.") %>%
-        cli_alert_danger()
-    }
-    cli_ul("Install/update {.val {pkg}} with the code below.")
-    cli_code(glue::glue('install.packages("{pkg}")'))
-    if (isTRUE(boolean)) return(FALSE)
-    stop("Install required package", call. = FALSE)
-  }
-
-  if (isTRUE(boolean)) return(TRUE)
+  # prompt user to install package ---------------------------------------------
+  rlang::check_installed(
+    pkg = pkg,
+    version = version,
+    reason = switch(!is.null(fn), stringr::str_glue("for `{fn}`"))
+  )
   invisible()
 }
 


### PR DESCRIPTION
* The `.assert_package()` now uses `rlang::check_installed()` and `rlang::is_installed()` to check whether needed packages are installed. The `rlang::check_installed()` prompts user to install needed package when run interactively. (#147)