### PR TITLE
Deprecate vars() as a selector

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: broom.helpers
 Title: Helpers for Model Coefficients Tibbles
-Version: 1.7.0.9000
+Version: 1.7.0.9001
 Authors@R: c(
     person("Joseph", "Larmarange", , "joseph@larmarange.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-7097-700X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # broom.helpers (development version)
 
+- Support for `dplyr::vars()` (also exported by {gtsummary}) as a selector has 
+  now been deprecated. Users will be warned that support for `vars()` will
+  eventually be removed from the package. (#154)
+
 - Support for `biglm::bigglm()` and `biglmm::bigglm()` models (#155)
 
 # broom.helpers 1.7.0

--- a/R/select_utilities.R
+++ b/R/select_utilities.R
@@ -231,6 +231,12 @@
   res <-
     tryCatch({
       if (select_input_starts_var) {
+        # `vars()` was deprecated on June 6, 2022, gtsummary will stop
+        # exporting `vars()` at some point as well.
+        paste("Use of {.code vars()} is now {.strong deprecated} and support will soon be removed.",
+              "Please replace calls to {.code vars()} with {.code c()}.") %>%
+          cli::cli_alert_warning()
+
         # `vars()` evaluates to a list of quosures; unquoting them in `select()`
         names(dplyr::select(data, !!!rlang::eval_tidy(select)))
       }


### PR DESCRIPTION
Support for `dplyr::vars()` (also exported by {gtsummary}) as a selector has now been deprecated. Users will be warned that support for `vars()` will eventually be removed from the package. (#154)

``` r
gtsummary::trial |> 
  gtsummary::tbl_summary(include = gtsummary::vars(age)) |> 
  gtsummary::as_kable()
#> ! Use of `vars()` is now deprecated and support will soon be removed. Please replace calls to `vars()` with `c()`.
```

| **Characteristic** | **N = 200** |
|:-------------------|:-----------:|
| Age                | 47 (38, 57) |
| Unknown            |     11      |

<sup>Created on 2022-06-06 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
