### PR TITLE
Avoid warnings about `exponentiate=` argument

### DIFF
--- a/R/tidy_and_attach.R
+++ b/R/tidy_and_attach.R
@@ -52,7 +52,7 @@ tidy_and_attach <- function(
   # test if exponentiate can be passed to tidy_fun, and if tidy_fun runs without error
   result <-
     tryCatch(
-      tidy_fun(model, exponentiate = exponentiate, ...) %>%
+      suppressWarnings(tidy_fun(model, exponentiate = exponentiate, ...)) %>%
         tidy_attach_model(model, .attributes = list(exponentiate = exponentiate)),
       error = function(e) {
         # `tidy_fun()` fails for two primary reasons:


### PR DESCRIPTION
I added a `suppressWarning()` around the evaluation of `tidy_fun=`. I see you are preparing a release, and I think this will be good to include.

Perhaps in the future we can implement a better solution...perhaps something like looking at the function's arguments and only passing `expoenentiat=` if the function has that arg?

``` r
survival::survreg(survival::Surv(time, status) ~ sex, data = survival::lung) |> 
  broom.helpers::tidy_plus_plus()
#> # A tibble: 1 × 19
#>   term  variable var_label var_class var_type   var_nlevels contrasts
#>   <chr> <chr>    <chr>     <chr>     <chr>            <int> <chr>    
#> 1 sex   sex      sex       numeric   continuous          NA <NA>     
#> # … with 12 more variables: contrasts_type <chr>, reference_row <lgl>,
#> #   label <chr>, n_obs <dbl>, n_event <dbl>, exposure <dbl>, estimate <dbl>,
#> #   std.error <dbl>, statistic <dbl>, p.value <dbl>, conf.low <dbl>,
#> #   conf.high <dbl>
```

<sup>Created on 2022-07-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
