### PR TITLE
`tidy_select_variables()` now sorts the variables according to `include`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # broom.helpers (development version)
 
+**New features**
+
+- `tidy_select_variables()` now sorts the variables according to `include` (#183)
+
 **New supported models**
 
 - Support for `logitr::logitr()` models (#179)

--- a/R/tidy_select_variables.R
+++ b/R/tidy_select_variables.R
@@ -55,6 +55,8 @@ tidy_select_variables <- function(
       .data$var_type == "intercept" |
         .data$variable %in% include
     ) %>%
+    dplyr::mutate(fct_variable = factor(.data$variable, levels = include)) %>%
+    dplyr::arrange(.data$fct_variable) %>%
+    dplyr::select(-.data$fct_variable) %>%
     tidy_attach_model(model = model, .attributes = .attributes)
-
 }

--- a/R/tidy_select_variables.R
+++ b/R/tidy_select_variables.R
@@ -50,13 +50,17 @@ tidy_select_variables <- function(
   # obtain character vector of selected variables
   include <- .select_to_varnames({{ include }}, var_info = x, arg_name = "include")
 
+  # order result, intercept first then by the order of include
   x %>%
     dplyr::filter(
       .data$var_type == "intercept" |
         .data$variable %in% include
     ) %>%
-    dplyr::mutate(fct_variable = factor(.data$variable, levels = include)) %>%
-    dplyr::arrange(.data$fct_variable) %>%
-    dplyr::select(-.data$fct_variable) %>%
+    dplyr::mutate(
+      log_intercept = .data$var_type == "intercept",
+      fct_variable = factor(.data$variable, levels = include)
+    ) %>%
+    dplyr::arrange(dplyr::desc(.data$log_intercept), .data$fct_variable) %>%
+    dplyr::select(-.data$log_intercept, -.data$fct_variable) %>%
     tidy_attach_model(model = model, .attributes = .attributes)
 }

--- a/R/tidy_select_variables.R
+++ b/R/tidy_select_variables.R
@@ -11,6 +11,9 @@
 #' syntax. Use `-` to remove a variable. Default is `everything()`.
 #' See also [all_continuous()], [all_categorical()], [all_dichotomous()]
 #' and [all_interaction()]
+#' @return
+#' The `x` tibble limited to the included variables (and eventually the intercept),
+#' sorted according to the `include` parameter.
 #'
 #' @param model the corresponding model, if not attached to `x`
 #' @export

--- a/man/tidy_select_variables.Rd
+++ b/man/tidy_select_variables.Rd
@@ -16,6 +16,10 @@ and \code{\link[=all_interaction]{all_interaction()}}}
 
 \item{model}{the corresponding model, if not attached to \code{x}}
 }
+\value{
+The \code{x} tibble limited to the included variables (and eventually the intercept),
+sorted according to the \code{include} parameter.
+}
 \description{
 Will remove unselected variables from the results.
 To remove the intercept, use \code{\link[=tidy_remove_intercept]{tidy_remove_intercept()}}.

--- a/tests/testthat/test-select_variables.R
+++ b/tests/testthat/test-select_variables.R
@@ -20,6 +20,18 @@ test_that("tidy_select_variables() works for basic models", {
     c("(Intercept)", "grade", "grade", "trt")
   )
 
+  res2 <- res %>% tidy_select_variables(include = c("trt", "grade"))
+  expect_equivalent(
+    res2$variable,
+    c("(Intercept)", "trt", "grade", "grade")
+  )
+
+  res2 <- res %>% tidy_select_variables(include = c(trt, grade, dplyr::everything()))
+  expect_equivalent(
+    res2$variable,
+    c("(Intercept)", "trt", "grade", "grade", "stage", "stage", "stage")
+  )
+
   # select and de-select
   expect_equivalent(
     res %>% tidy_select_variables(include = stage),
@@ -51,6 +63,21 @@ test_that("tidy_select_variables() works for basic models", {
     res %>% tidy_select_variables(include = where(is.character)),
     NA
   )
+
+  # interaction
+  mod <- glm(response ~ stage + grade * trt, gtsummary::trial, family = binomial)
+  res <- mod %>%
+    tidy_and_attach() %>%
+    tidy_identify_variables()
+  res2 <- res %>% tidy_select_variables(include = c(trt, grade, dplyr::everything()))
+  expect_equivalent(
+    res2$variable,
+    c(
+      "(Intercept)", "trt", "grade", "grade", "stage", "stage", "stage",
+      "grade:trt", "grade:trt"
+    )
+  )
+
 })
 
 


### PR DESCRIPTION
Fix #183 