### PR TITLE
`tidy_parameters()` calls now `parameters::model_parameters()` with `…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - new argument `model_matrix_attr` in `tidy_and_attach()` and `tidy_plus_plus()`
   to attach model frame and model matrix to the model as attributes for saving
   some execution time (#254)
+- by default, `tidy_parameters()` calls now `parameters::model_parameters()`
+  with `pretty_names = FALSE` for saving execution time (#259)
   
 **Deprecated support**
 

--- a/R/custom_tidiers.R
+++ b/R/custom_tidiers.R
@@ -23,6 +23,7 @@ tidy_parameters <- function(x, conf.int = TRUE, conf.level = .95, ...) {
   if (!conf.int) conf.level <- NULL
   args$ci <- conf.level
   args$model <- x
+  if (is.null(args$pretty_names)) args$pretty_names <- FALSE
 
   if (
     inherits(x, "betareg") &&


### PR DESCRIPTION
…pretty_names = FALSE` for saving execution time

fix #259