### PR TITLE
Tiny typo

### DIFF
--- a/data-raw/DATASET.R
+++ b/data-raw/DATASET.R
@@ -53,7 +53,7 @@ supported_models <-
     "`pscl::zeroinfl()`", "Use `tidy_zeroinfl()` as `tidy_fun`.",
     "`pscl::hurdle()`", "Use `tidy_zeroinfl()` as `tidy_fun`.",
     "`betareg::betareg()`", "Use `tidy_parameters()` as `tidy_fun` with `component` argument to control with coefficients to return. `broom::tidy()` does not support the `exponentiate` argument for betareg models, use `tidy_parameters()` instead.", # nolint
-    "`survival::cch()`", "`Experimental support.",
+    "`survival::cch()`", "Experimental support.",
     "`glmtoolbox::glmgee()`", "",
   ) |>
   dplyr::arrange(.data$model, .locale = "en")


### PR DESCRIPTION
Thanks for a great package.

I was reading the table in https://larmarange.github.io/broom.helpers/articles/tidy.html#supported-models and spotted what I think is an extra backtick which I've deleted.

<img width="309" alt="CleanShot 2025-01-09 at 11 25 37@2x" src="https://github.com/user-attachments/assets/955218fa-84d0-4c95-838b-e99f59b13e8b" />
